### PR TITLE
update leaflet version in documentation, fix markdown toc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If it fails, make sure that your plugin is correctly built and accessible with y
 ### Other resources
  - [How Windy Plugin work](docs/WINDY_PLUGIN.md)
  - [Windy API documentation](docs/WINDY_API.md)
- - [Leaflet 0.7.7 documentation](https://leafletjs.com/reference-0.7.7.html)
+ - [Leaflet 1.4.0 documentation](https://leafletjs.com/reference-1.4.0.html)
  - [List of Leaflet Plugins](https://leafletjs.com/plugins.html)
  - [Windy Plugins technical forum](https://community.windy.com/category/21/windy-plugins)
 

--- a/docs/WINDY_API.md
+++ b/docs/WINDY_API.md
@@ -16,14 +16,14 @@
   * [overlays.ident.convertMetric(number)](#overlaysidentconvertmetricnumber)
 - [Module: utils](#module-utils)
   * [utils.loadScript(url)](#utilsloadscripturl)
-  * [utils.wind2obj(obj)](#utilswind2objobj)
-  * [utils.wave2obj(obj)](#utilswave2objobj)
+  * [utils.wind2obj(arr)](#utilswind2objarr)
+  * [utils.wave2obj(arr)](#utilswave2objarr)
 - [Module: plugins](#module-plugins)
 - [Module: picker](#module-picker)
   * [Converting raw meteorological values to readable numbers](#converting-raw-meteorological-values-to-readable-numbers)
 - [Module: interpolator](#module-interpolator)
   * [interpolatorFun({ lat, lon })](#interpolatorfun-lat-lon-)
-- [Module: pluginDataLoader](#module-plugindataloader)
+- [Module: pluginDataLoader](#module-plugin-data-loader)
 
 <!-- tocstop -->
 

--- a/docs/WINDY_PLUGIN.md
+++ b/docs/WINDY_PLUGIN.md
@@ -35,7 +35,7 @@ plugin.less 	// <-- optional
 otherFiles.mjs 	// <-- optional
 ```
 
-**plugin.html**
+#### plugin.html
 Similar to vue, svelte or riot tag, contains html, and also js code of your plugin.
 
 ```html
@@ -55,7 +55,7 @@ Similar to vue, svelte or riot tag, contains html, and also js code of your plug
 </plugin>
 ```
 
-**plugin.less**
+#### plugin.less
 Your plugin will be wrapped inside `#windy-plugin-anyName` DIV. Whenever `.onwindy-plugin-anyName` class is applied to `<body>` of the page, you have chance to modify other styles on page.
 
 ```css
@@ -68,7 +68,7 @@ Your plugin will be wrapped inside `#windy-plugin-anyName` DIV. Whenever `.onwin
 }
 ```
 
-**config.js**
+#### config.js
 Basic configuration of your plugin has node.js module syntax. Remember, that `name` of your plugin, `description` and `author` is defined in your `package.json`.
 
 ```js

--- a/examples/01-hello-world/README.md
+++ b/examples/01-hello-world/README.md
@@ -1,10 +1,6 @@
 ![](https://www.windy.com/img/windy-plugins/example01.gif)
 # Hello world
-Windy uses Leaflet version `0.7.7` that is [well documented here](http://leafletjs.com/reference-0.7.7.html) and contains plenty of [plugins that you can use](http://leafletjs.com/plugins.html).
-
- > We have tried Leaflet version 1.0.0 and 1.3.4 in the past, but we have
- > found new versions slower, and containing major design flaw. Therefore we
- > stay with Leaflet 0.7.7. Also we miss some plugins, that were not ported.
+Windy uses Leaflet version `1.4.0` that is [well documented here](https://leafletjs.com/reference-1.4.0.html) and contains plenty of [plugins that you can use](http://leafletjs.com/plugins.html).
 
 ### config.js
 This is main configuration file for your plugin.


### PR DESCRIPTION
Main and "hello world" example readmes contained older versions of Leaflet.

I also found out that some toc links were not working, so I fixed it.