### PR TITLE
update actions/checkout to v7

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -9,7 +9,7 @@ jobs:
         env:
             WINDY_API_KEY: '${{ secrets.WINDY_API_KEY }}'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v7
             - name: Build
               run: |
                   npm install


### PR DESCRIPTION
github generates a warning for me (despite I'm already on v4) because the action uses Node 20. This PR updates to the latest action version.