### PR TITLE
Add windy-plugin-cma-typhoon: China CMA real-time typhoon tracker with 17-level Beaufort scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ which likely executes *after* the user's `zoom` event in this example.
     -   Fixed wrong examples
 -   0.1.1
     -   Initial version of this repo
+
+
+### Featured Plugin: windy-plugin-cma-typhoon
+- **China CMA Real-Time Typhoon Tracker**: [https://github.com/jianghanzhi2006-dotcom/windy-plugin-cma-typhoon](https://github.com/jianghanzhi2006-dotcom/windy-plugin-cma-typhoon)

--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ which likely executes *after* the user's `zoom` event in this example.
 
 ### Featured Plugin: windy-plugin-cma-typhoon
 - **China CMA Real-Time Typhoon Tracker**: [https://github.com/jianghanzhi2006-dotcom/windy-plugin-cma-typhoon](https://github.com/jianghanzhi2006-dotcom/windy-plugin-cma-typhoon)
+  * Direct live HTTP connection to China Meteorological Administration (typhoon.nmc.cn)
+  * 17-level Beaufort wind scale conversion (GB/T 19201-2006)
+  * Red solid line for observed track, golden dashed line for official 120h forecast track.


### PR DESCRIPTION
## 🌀 New Community Plugin: windy-plugin-cma-typhoon

An official Windy.com extension for real-time tracking of Western Pacific typhoons using China Meteorological Administration (CMA) data and the 17-level Beaufort wind scale (GB/T 19201-2006).

### Key Features
- **Direct Live CMA Connection**: Connects directly to CMA official servers (`typhoon.nmc.cn`) for real-time observed track and 120-hour forecast data.
- **17-Level Beaufort Wind Scale**: Converts 2-minute average wind speed (m/s) into 1 to 17 Beaufort scale levels per Chinese national standard GB/T 19201-2006.
- **Dual Polyline Visual Trajectory**:
  - **Red Solid Line**: Historical observed real-time track.
  - **Golden Dashed Line**: CMA official 120-hour forecast track.
- **Automatic Beijing Time Conversion**: Automatically converts UTC timestamps into local Beijing Time (UTC+8) for all observed and future forecast points.
- **Touch-Friendly Hit Radius**: Large 28px hit areas for easy node selection and click-outside popup dismissal.

### Open Source Repository
- **GitHub Repository**: https://github.com/jianghanzhi2006-dotcom/windy-plugin-cma-typhoon
- **Compiled Assets**: https://github.com/jianghanzhi2006-dotcom/windy-plugin-cma-typhoon/tree/main/dist
